### PR TITLE
Explosive tools now trigger breaking events from other plugins (and c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Custom item settings can be changed in `plugins/Slimefun/Items.yml`
 **Dolly**: Allows players to pick up chests and place them back down elsewhere, while retaining their inventories.
 
 ## Tools
-**Upgraded Explosive Pickaxe & Upgraded Explosive Shovel**: 5x5 variants of the default explosive tools, and break 5 blocks in front of the player instead of 2 blocks all around. This feature can be toggled in Items.yml.
+**Upgraded Explosive Pickaxe & Upgraded Explosive Shovel**: 5x5 variants of the default explosive tools, and break 5 blocks in front of the player instead of 2 blocks all around. By default, these tools trigger other plugins that listen to block breaks, i.e. McMMO (Players get xp for every block broken). These features can be toggled in Items.yml.
 
 **Upgraded Lumber Axe**: Breaks all logs within 2 blocks of each other, as opposed to adjacent blocks that the default lumber axe targets. Intended to be used for strange trees like acacia and jungle, and even custom trees.
 


### PR DESCRIPTION
…an be turned off in Items.yml)

## Short Description
<!-- Please explain what you changed/added and why you did it in detail. -->

## Additions/Changes/Removals
<!-- Please list all the changes you have made. -->

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Video Proof
<!-- Attach video proof that what you added works -->
<!-- Avoid recording using a phone unless absolutely necessary -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have tested every variant of every item or config setting that I have added.
- [ ] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
