### PR TITLE
Fix error on server startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>com.github.Slimefun-Addon-Community</groupId>
             <artifactId>extrautils</artifactId>
-            <version>cea1be6550</version>
+            <version>73e76ac06c</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Short Description
Update pom because `extrautils` dependency was outdated and it causing that error on startup:
```
[19:45:09 ERROR]: Error occurred while enabling FluffyMachines vDEV - 89 (git 2c269d47) (Is it up to date?)
java.lang.NoClassDefFoundError: io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin
at dev.j3fftw.extrautils.utils.Constants.<clinit>(Constants.java:10) ~[FluffyMachines - DEV 88 (git a1b54)(1).jar:?]
at dev.j3fftw.extrautils.utils.Utils.perTickToPerSecond(Utils.java:48) ~[FluffyMachines - DEV 88 (git a1b54)(1).jar:?]
at dev.j3fftw.extrautils.utils.LoreBuilderDynamic.powerPerTick(LoreBuilderDynamic.java:23) ~[FluffyMachines - DEV 88 (git a1b54)(1).jar:?]
at io.ncbpfluffybear.fluffymachines.utils.FluffyItems.<clinit>(FluffyItems.java:235) ~[FluffyMachines - DEV 88 (git a1b54)(1).jar:?]
at io.ncbpfluffybear.fluffymachines.FluffyItemSetup.setup(FluffyItemSetup.java:57) ~[FluffyMachines - DEV 88 (git a1b54)(1).jar:?]
at io.ncbpfluffybear.fluffymachines.FluffyMachines.onEnable(FluffyMachines.java:143) ~[FluffyMachines - DEV 88 (git a1b54)(1).jar:?]
at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:264) ~[patched_1.17.1.jar:git-Paper-226]
at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:370) ~[patched_1.17.1.jar:git-Paper-226]
at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:500) ~[patched_1.17.1.jar:git-Paper-226]
at org.bukkit.craftbukkit.v1_17_R1.CraftServer.enablePlugin(CraftServer.java:535) ~[patched_1.17.1.jar:git-Paper-226]
at org.bukkit.craftbukkit.v1_17_R1.CraftServer.enablePlugins(CraftServer.java:449) ~[patched_1.17.1.jar:git-Paper-226]
at net.minecraft.server.MinecraftServer.loadWorld(MinecraftServer.java:654) ~[patched_1.17.1.jar:git-Paper-226]
at net.minecraft.server.dedicated.DedicatedServer.init(DedicatedServer.java:306) ~[patched_1.17.1.jar:git-Paper-226]
at net.minecraft.server.MinecraftServer.x(MinecraftServer.java:1141) ~[patched_1.17.1.jar:git-Paper-226]
at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:318) ~[patched_1.17.1.jar:git-Paper-226]
at java.lang.Thread.run(Thread.java:831) [?:?]
Caused by: java.lang.ClassNotFoundException: io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin
at org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:146) ~[patched_1.17.1.jar:git-Paper-226]
at org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:103) ~[patched_1.17.1.jar:git-Paper-226]
at java.lang.ClassLoader.loadClass(ClassLoader.java:519) ~[?:?]
... 16 more
```

## Additions/Changes/Removals
Updated `ExtraUtils` dependency

## Related Issues

## Video Proof

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have tested every variant of every item or config setting that I have added.
- [ ] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
