### PR TITLE
Fix broken spanwners recipe in ancient altar

### DIFF
--- a/src/main/java/io/ncbpfluffybear/fluffymachines/machines/AutoAncientAltar.java
+++ b/src/main/java/io/ncbpfluffybear/fluffymachines/machines/AutoAncientAltar.java
@@ -9,6 +9,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AltarRecipe;
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientAltar;
+import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.BrokenSpawner;
 import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.RepairedSpawner;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.ncbpfluffybear.fluffymachines.utils.Constants;
@@ -335,14 +336,21 @@ public class AutoAncientAltar extends SlimefunItem implements EnergyNetComponent
         if (Constants.isSoulJarsInstalled && sfCatalyst != null
             && sfCatalyst.getId().startsWith("FILLED") && sfCatalyst.getId().endsWith("SOUL_JAR")) {
 
-            SlimefunItem spawnerItem = SlimefunItem.getById(sfCatalyst.getId().replace("FILLED_", "").replace(
-                "_SOUL_JAR", "_BROKEN_SPAWNER"));
+//            SlimefunItem spawnerItem = SlimefunItem.getById(sfCatalyst.getId().replace("FILLED_", "").replace(
+//            "_SOUL_JAR", "_BROKEN_SPAWNER"));
+            EntityType entityType = EntityType.valueOf(sfCatalyst.getId()
+                    .replace("FILLED_", "")
+                    .replace("_SOUL_JAR", ""));
+
+            BrokenSpawner brokenSpawner = SlimefunItems.BROKEN_SPAWNER.getItem(BrokenSpawner.class);
+            ItemStack spawnerItem = brokenSpawner.getItemForEntityType(entityType);
+
             if (pedestalItems.equals(jarInputs) && spawnerItem != null) {
                 removeCharge(block.getLocation(), ENERGY_CONSUMPTION);
                 for (int slot : getInputSlots()) {
                     menu.consumeItem(slot);
                 }
-                menu.pushItem(spawnerItem.getItem().clone(), getOutputSlots());
+                menu.pushItem(spawnerItem.clone(), getOutputSlots());
             }
         } else if (SlimefunUtils.isItemSimilar(catalystItem, SlimefunItems.BROKEN_SPAWNER, false, false)) {
 

--- a/src/main/java/io/ncbpfluffybear/fluffymachines/machines/AutoAncientAltar.java
+++ b/src/main/java/io/ncbpfluffybear/fluffymachines/machines/AutoAncientAltar.java
@@ -341,6 +341,8 @@ public class AutoAncientAltar extends SlimefunItem implements EnergyNetComponent
                         .replace("FILLED_", "")
                         .replace("_SOUL_JAR", ""));
 
+                if (entityType == EntityType.UNKNOWN) { return; }
+
                 BrokenSpawner brokenSpawner = SlimefunItems.BROKEN_SPAWNER.getItem(BrokenSpawner.class);
                 ItemStack spawnerItem = brokenSpawner.getItemForEntityType(entityType);
 

--- a/src/main/java/io/ncbpfluffybear/fluffymachines/machines/AutoAncientAltar.java
+++ b/src/main/java/io/ncbpfluffybear/fluffymachines/machines/AutoAncientAltar.java
@@ -339,9 +339,12 @@ public class AutoAncientAltar extends SlimefunItem implements EnergyNetComponent
             try {
                 EntityType entityType = EntityType.valueOf(sfCatalyst.getId()
                         .replace("FILLED_", "")
-                        .replace("_SOUL_JAR", ""));
+                        .replace("_SOUL_JAR", "")
+                );
 
-                if (entityType == EntityType.UNKNOWN) { return; }
+                if (entityType == EntityType.UNKNOWN) {
+                    return;
+                }
 
                 BrokenSpawner brokenSpawner = SlimefunItems.BROKEN_SPAWNER.getItem(BrokenSpawner.class);
                 ItemStack spawnerItem = brokenSpawner.getItemForEntityType(entityType);

--- a/src/main/java/io/ncbpfluffybear/fluffymachines/machines/AutoAncientAltar.java
+++ b/src/main/java/io/ncbpfluffybear/fluffymachines/machines/AutoAncientAltar.java
@@ -336,22 +336,23 @@ public class AutoAncientAltar extends SlimefunItem implements EnergyNetComponent
         if (Constants.isSoulJarsInstalled && sfCatalyst != null
             && sfCatalyst.getId().startsWith("FILLED") && sfCatalyst.getId().endsWith("SOUL_JAR")) {
 
-//            SlimefunItem spawnerItem = SlimefunItem.getById(sfCatalyst.getId().replace("FILLED_", "").replace(
-//            "_SOUL_JAR", "_BROKEN_SPAWNER"));
-            EntityType entityType = EntityType.valueOf(sfCatalyst.getId()
-                    .replace("FILLED_", "")
-                    .replace("_SOUL_JAR", ""));
+            try {
+                EntityType entityType = EntityType.valueOf(sfCatalyst.getId()
+                        .replace("FILLED_", "")
+                        .replace("_SOUL_JAR", ""));
 
-            BrokenSpawner brokenSpawner = SlimefunItems.BROKEN_SPAWNER.getItem(BrokenSpawner.class);
-            ItemStack spawnerItem = brokenSpawner.getItemForEntityType(entityType);
+                BrokenSpawner brokenSpawner = SlimefunItems.BROKEN_SPAWNER.getItem(BrokenSpawner.class);
+                ItemStack spawnerItem = brokenSpawner.getItemForEntityType(entityType);
 
-            if (pedestalItems.equals(jarInputs) && spawnerItem != null) {
-                removeCharge(block.getLocation(), ENERGY_CONSUMPTION);
-                for (int slot : getInputSlots()) {
-                    menu.consumeItem(slot);
+                if (pedestalItems.equals(jarInputs)) {
+                    removeCharge(block.getLocation(), ENERGY_CONSUMPTION);
+                    for (int slot : getInputSlots()) {
+                        menu.consumeItem(slot);
+                    }
+                    menu.pushItem(spawnerItem.clone(), getOutputSlots());
                 }
-                menu.pushItem(spawnerItem.clone(), getOutputSlots());
-            }
+            } catch (IllegalArgumentException ignored) {}
+
         } else if (SlimefunUtils.isItemSimilar(catalystItem, SlimefunItems.BROKEN_SPAWNER, false, false)) {
 
             Optional<ItemStack> result = checkRecipe(SlimefunItems.BROKEN_SPAWNER, pedestalItems);


### PR DESCRIPTION
## Short Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Fix the broken spawner recipe output using soul jars as catalyst. 
The `MOB_TYPE_BROKEN_SPAWNER` item are used to display the recipe only, the output is not the same as the displayed item, so I change the output, players can use them for crafting reinforced spawners.

## Additions/Changes/Removals
<!-- Please list all the changes you have made. -->
Change the recipe output for broken spawner.
I keep the old item, if the displayed broken spawner can be used for crafting reinforced spawners, this code snippet can be removed.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Fix #98

## Video Proof
<!-- Attach video proof that what you added works -->
<!-- Avoid recording using a phone unless absolutely necessary -->
https://youtu.be/sIwa_7pcGqM

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have tested every variant of every item or config setting that I have added.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
