### PR TITLE
Fix trigger-other-plugins

### DIFF
--- a/src/main/java/io/ncbpfluffybear/fluffymachines/items/tools/UpgradedExplosiveTool.java
+++ b/src/main/java/io/ncbpfluffybear/fluffymachines/items/tools/UpgradedExplosiveTool.java
@@ -166,17 +166,15 @@ class UpgradedExplosiveTool extends ExplosiveTool {
         // Don't break SF blocks
         if (sfItem != null) {
             return;
-        } else {
-            b.breakNaturally(item);
         }
-
-        damageItem(p, item);
 
         if (triggerOtherPlugins.getValue()) {
             AlternateBreakEvent breakEvent = new AlternateBreakEvent(b, p);
             Bukkit.getServer().getPluginManager().callEvent(breakEvent);
         }
 
-    }
+        b.breakNaturally(item);
 
+        damageItem(p, item);
+    }
 }

--- a/src/main/java/io/ncbpfluffybear/fluffymachines/items/tools/UpgradedLumberAxe.java
+++ b/src/main/java/io/ncbpfluffybear/fluffymachines/items/tools/UpgradedLumberAxe.java
@@ -61,10 +61,10 @@ public class UpgradedLumberAxe extends SimpleSlimefunItem<ItemUseHandler> implem
                 for (Block b : logs) {
                     if (Slimefun.getProtectionManager().hasPermission(e.getPlayer(), b,
                         Interaction.BREAK_BLOCK) && BlockStorage.checkID(b) == null) {
-                        b.breakNaturally(tool);
                         if (triggerOtherPlugins.getValue()) {
                             Bukkit.getPluginManager().callEvent(new AlternateBreakEvent(b, e.getPlayer()));
                         }
+                        b.breakNaturally(tool);
                     }
                 }
             }


### PR DESCRIPTION
## Short Description
Other plugins could detect air at the block break location, resolve with reorder of calls.

## Additions/Changes/Removals
Call AlternateBreakEvent before breakNaturally

## Related Issues
Resolves #142 

## Image Proof
![image](https://github.com/NCBPFluffyBear/FluffyMachines/assets/5272660/6119063a-3776-4976-9cb4-45f5beb69f30)

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have tested every variant of every item or config setting that I have added.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
