### PR TITLE
Resolve stackoverflow with UpgradedLumberAxe

### DIFF
--- a/src/main/java/io/ncbpfluffybear/fluffymachines/items/tools/UpgradedExplosiveTool.java
+++ b/src/main/java/io/ncbpfluffybear/fluffymachines/items/tools/UpgradedExplosiveTool.java
@@ -166,17 +166,15 @@ class UpgradedExplosiveTool extends ExplosiveTool {
         // Don't break SF blocks
         if (sfItem != null) {
             return;
-        } else {
-            b.breakNaturally(item);
         }
-
-        damageItem(p, item);
 
         if (triggerOtherPlugins.getValue()) {
             AlternateBreakEvent breakEvent = new AlternateBreakEvent(b, p);
             Bukkit.getServer().getPluginManager().callEvent(breakEvent);
         }
 
-    }
+        b.breakNaturally(item);
 
+        damageItem(p, item);
+    }
 }

--- a/src/main/java/io/ncbpfluffybear/fluffymachines/items/tools/UpgradedLumberAxe.java
+++ b/src/main/java/io/ncbpfluffybear/fluffymachines/items/tools/UpgradedLumberAxe.java
@@ -65,10 +65,10 @@ public class UpgradedLumberAxe extends SimpleSlimefunItem<ItemUseHandler> implem
                 for (Block b : logs) {
                     if (Slimefun.getProtectionManager().hasPermission(e.getPlayer(), b,
                         Interaction.BREAK_BLOCK) && BlockStorage.checkID(b) == null) {
-                        b.breakNaturally(tool);
                         if (triggerOtherPlugins.getValue()) {
                             Bukkit.getPluginManager().callEvent(new AlternateBreakEvent(b, e.getPlayer()));
                         }
+                        b.breakNaturally(tool);
                     }
                 }
             }

--- a/src/main/java/io/ncbpfluffybear/fluffymachines/items/tools/UpgradedLumberAxe.java
+++ b/src/main/java/io/ncbpfluffybear/fluffymachines/items/tools/UpgradedLumberAxe.java
@@ -54,6 +54,10 @@ public class UpgradedLumberAxe extends SimpleSlimefunItem<ItemUseHandler> implem
                     return;
                 }
 
+                if (e instanceof AlternateBreakEvent) {
+                    return;
+                }
+
                 List<Block> logs = find(e.getBlock(), MAX_BROKEN, b -> Tag.LOGS.isTagged(b.getType()));
 
                 logs.remove(e.getBlock());


### PR DESCRIPTION
## Short Description
Resolved issue with [stackoverflow](https://paste.shockbyte.com/jegicotabihuqebariru) on lumber axe

I had this fixed on my local branch but apparently I hadn't squashed it into the main commit *facepalm*

## Additions/Changes/Removals
Add check to ignore AlternateBlockBreakEvent in UpgradedLumberAxe ToolHandler

## Related Issues
Resolves #142 and #144

## Video Proof
Upgraded Lumber Axe
![Upgraded Lumber Axe](https://i.gyazo.com/01519b21831a2fac03720f4335ba8278.gif)

Upgraded Explosive Pick
![Upgraded Explosive Pick](https://i.gyazo.com/ab7cf0daf14e93e728c1978db75bc2d4.gif)

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have tested every variant of every item or config setting that I have added.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
